### PR TITLE
Improve error reporting when fetching NFT collection index

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,14 @@ async function getCollectionIndex() {
       stack: []
     })
   });
+  if (!res.ok) {
+    throw new Error('HTTP ' + res.status + ' ' + res.statusText);
+  }
   const data = await res.json();
-  if (!data.ok) throw new Error('Ошибка get_collection_data: ' + data.description);
+  if (!data.ok) {
+    const msg = data.error?.message || data.description || JSON.stringify(data);
+    throw new Error('Ошибка get_collection_data: ' + msg);
+  }
   const stack = data.result.stack;
   // Первый элемент — next_item_index
   return BigInt(stack[0][1]);


### PR DESCRIPTION
## Summary
- provide detailed errors when the `get_collection_data` call fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68653701a2348330a4560d23560990b0